### PR TITLE
Add DeepL as translation service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor
 .phpunit.result.cache
+.php-cs-fixer.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "php": "^8.1",
         "nikic/php-parser": "^v5.2",
         "google/cloud-translate": "^1.17",
-        "openai-php/client": "^0.10.1"
+        "openai-php/client": "^0.10.1",
+        "deeplcom/deepl-php": "^1.9"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54b2eb0406c17ff6face19813374420a",
+    "content-hash": "7939a7b956d5a31121e191f5aebdc1ea",
     "packages": [
         {
             "name": "brick/math",
@@ -65,6 +65,69 @@
                 }
             ],
             "time": "2023-11-29T23:19:16+00:00"
+        },
+        {
+            "name": "deeplcom/deepl-php",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DeepLcom/deepl-php.git",
+                "reference": "fdf86cce24718d0ca4fa237e809951ec0d4835a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DeepLcom/deepl-php/zipball/fdf86cce24718d0ca4fa237e809951ec0d4835a8",
+                "reference": "fdf86cce24718d0ca4fa237e809951ec0d4835a8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.3.0",
+                "php-http/discovery": "^1.18",
+                "php-http/multipart-stream-builder": "^1.3",
+                "psr/http-client": "^1.0",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "guzzlehttp/guzzle": "^7.7.0",
+                "php-mock/php-mock-phpunit": "^2.6",
+                "phpunit/phpunit": "^9",
+                "ramsey/uuid": "^4.2",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "DeepL SE",
+                    "email": "open-source@deepl.com"
+                }
+            ],
+            "description": "Official DeepL API Client Library",
+            "keywords": [
+                "api",
+                "deepl",
+                "translation",
+                "translator"
+            ],
+            "support": {
+                "issues": "https://github.com/DeepLcom/deepl-php/issues",
+                "source": "https://github.com/DeepLcom/deepl-php/tree/v1.9.0"
+            },
+            "time": "2024-09-17T08:33:38+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -10978,5 +11041,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/translator.php
+++ b/config/translator.php
@@ -10,7 +10,7 @@ return [
       | using this translation library. This service is used when another is
       | not explicitly specified when executing a given translation function.
       |
-      | Supported: "google", "openai"
+      | Supported: "google", "openai", "deepl"
       |
       */
     'default' => env('DEFAULT_TRANSLATOR_SERVICE', 'openai'),
@@ -28,6 +28,10 @@ return [
             'model' => env('OPENAI_MODEL', 'gpt-4o'),
             'api_key' => env('OPENAI_API_KEY'),
             'organization_id' => env('OPENAI_ORGANIZATION'),
+        ],
+        'deepl' => [
+            'driver' => Bottelet\TranslationChecker\Translator\DeeplTranslator::class,
+            'api_key' => env('DEEPL_API_KEY'),
         ],
     ],
     'source_paths' => [

--- a/docs/translation-service.md
+++ b/docs/translation-service.md
@@ -28,12 +28,19 @@ GOOGLE_TRANSLATE_CLIENT_CERT_URL=your_client_cert_url
 ```
 See more here: [Google Translate Setup](https://cloud.google.com/translate/docs/setup)
 
+For DeepL, you need to set the following environment variable
+```bash
+DEEPL_API_KEY=your_api_key
+```
+See more here: [DeepL API Authentication](https://developers.deepl.com/docs/getting-started/auth#authentication)
+
 ### Default Service
 The `default` configuration option specifies the class to be used for automatic translation. This service will be used for translating strings.
 
-There are currently two built-in translation services:
+There are currently three built-in translation services:
 1. **GoogleTranslateService** - Translates strings using Google Translate
 2. **OpenAIService** - Translates strings using OpenAI's API
+3. **DeepLService** - Translates strings using DeepL's API
 
 
 You can create your own translation service by implementing the `Bottelet\TranslationChecker\Translator\TranslatorContract` and overwriting the `default` configuration option.

--- a/src/TranslationCheckerServiceProvider.php
+++ b/src/TranslationCheckerServiceProvider.php
@@ -4,10 +4,12 @@ namespace Bottelet\TranslationChecker;
 
 use Bottelet\TranslationChecker\Sort\AlphabeticSort;
 use Bottelet\TranslationChecker\Sort\SorterContract;
+use Bottelet\TranslationChecker\Translator\DeeplTranslator;
 use Bottelet\TranslationChecker\Translator\GoogleTranslator;
 use Bottelet\TranslationChecker\Translator\OpenAiTranslator;
 use Bottelet\TranslationChecker\Translator\TranslatorContract;
 use Bottelet\TranslationChecker\Translator\VariableHandlers\VariableRegexHandler;
+use DeepL\Translator;
 use Google\Cloud\Translate\V2\TranslateClient;
 use Illuminate\Support\ServiceProvider;
 use OpenAI;
@@ -46,6 +48,13 @@ class TranslationCheckerServiceProvider extends ServiceProvider
 
             return new OpenAiTranslator(
                 $factory->withHttpHeader('OpenAI-Beta', 'assistants=v2')->make()
+            );
+        });
+
+        $this->app->bind(DeeplTranslator::class, function ($app) {
+            return new DeeplTranslator(
+                $app->make(VariableRegexHandler::class),
+                new Translator($app->config['translator.translators.deepl.api_key'])
             );
         });
     }

--- a/src/Translator/DeeplTranslator.php
+++ b/src/Translator/DeeplTranslator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bottelet\TranslationChecker\Translator;
+
+use Bottelet\TranslationChecker\Translator\VariableHandlers\VariableRegexHandler;
+use DeepL\Translator;
+
+class DeeplTranslator implements TranslatorContract
+{
+    public function __construct(
+        protected VariableRegexHandler $variableHandler,
+        protected Translator $translateClient,
+    ) {
+    }
+
+    /**
+     * @throws \DeepL\DeepLException
+     */
+    public function translate(string $text, string $targetLanguage, string $sourceLanguage = 'en'): string
+    {
+        $replaceVariablesText = $this->variableHandler->replacePlaceholders($text);
+
+        $translation = $this->translateClient->translateText($replaceVariablesText, $sourceLanguage, $targetLanguage);
+
+        return $this->variableHandler->restorePlaceholders($translation->text);
+    }
+
+    /**
+     * @param  array<string>  $texts
+     * @return array<string>
+     *
+     * @throws \DeepL\DeepLException
+     */
+    public function translateBatch(array $texts, string $targetLanguage, string $sourceLanguage = 'en'): array
+    {
+        $textsToTranslate = array_map([$this->variableHandler, 'replacePlaceholders'], $texts);
+
+        $translations = $this->translateClient->translateText($textsToTranslate, $sourceLanguage, $targetLanguage);
+
+        $translatedKeys = [];
+        foreach ($translations as $index => $translation) {
+            $translatedText = isset($translation->text) ? $this->variableHandler->restorePlaceholders($translation->text) : '';
+            $translatedKeys[$texts[$index]] = $translatedText ?: '';
+        }
+
+        return $translatedKeys;
+    }
+
+    public function isConfigured(): bool
+    {
+        /** @var array<string, null|string> $deeplConfig */
+        $deeplConfig = config('translator.translators.deepl');
+
+        return !in_array(null, $deeplConfig, true);
+    }
+}

--- a/src/Translator/DeeplTranslator.php
+++ b/src/Translator/DeeplTranslator.php
@@ -41,8 +41,7 @@ class DeeplTranslator implements TranslatorContract
 
         $translatedKeys = [];
         foreach ($translations as $index => $translation) {
-            $translatedText = isset($translation->text) ? $this->variableHandler->restorePlaceholders($translation->text) : '';
-            $translatedKeys[$texts[$index]] = $translatedText ?: '';
+            $translatedKeys[$texts[$index]] = $this->variableHandler->restorePlaceholders($translation->text);
         }
 
         return $translatedKeys;

--- a/tests/Finder/MissingKeysFinderTest.php
+++ b/tests/Finder/MissingKeysFinderTest.php
@@ -136,7 +136,6 @@ class MissingKeysFinderTest extends TestCase
         $this->assertArrayHasKey('A sentence that should be added to the translation file', $foundStrings);
     }
 
-
     #[Test]
     public function findMissingTranslatableStringUseKeyAsDefaultValue(): void
     {
@@ -145,6 +144,5 @@ class MissingKeysFinderTest extends TestCase
 
         $foundStrings = $translationFinder->findMissingTranslatableStrings([$multiFunctionFile], []);
         $this->assertSame(['da.key.test' => 'da.key.test', 'a long string' => 'a long string'], $foundStrings);
-
     }
 }

--- a/tests/Translator/DeeplTranslatorTest.php
+++ b/tests/Translator/DeeplTranslatorTest.php
@@ -3,7 +3,6 @@
 namespace Bottelet\TranslationChecker\Tests\Translator;
 
 use Bottelet\TranslationChecker\Translator\DeeplTranslator;
-use Bottelet\TranslationChecker\Translator\GoogleTranslator;
 use Bottelet\TranslationChecker\Translator\VariableHandlers\VariableRegexHandler;
 use DeepL\TextResult;
 use DeepL\Translator;
@@ -91,7 +90,6 @@ class DeeplTranslatorTest extends \Bottelet\TranslationChecker\Tests\TestCase
     public function testDeeplTranslatorHasValidCredentials(): void
     {
         $this->assertTrue($this->deeplTranslator->isConfigured());
-        ;
     }
 
     #[Test]
@@ -101,6 +99,5 @@ class DeeplTranslatorTest extends \Bottelet\TranslationChecker\Tests\TestCase
             'api_key' => null,
         ]);
         $this->assertFalse($this->deeplTranslator->isConfigured());
-        ;
     }
 }

--- a/tests/Translator/DeeplTranslatorTest.php
+++ b/tests/Translator/DeeplTranslatorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Bottelet\TranslationChecker\Tests\Translator;
+
+use Bottelet\TranslationChecker\Translator\DeeplTranslator;
+use Bottelet\TranslationChecker\Translator\GoogleTranslator;
+use Bottelet\TranslationChecker\Translator\VariableHandlers\VariableRegexHandler;
+use DeepL\TextResult;
+use DeepL\Translator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class DeeplTranslatorTest extends \Bottelet\TranslationChecker\Tests\TestCase
+{
+    /** @var VariableRegexHandler|MockObject */
+    private $variableHandlerMock;
+
+    /** @var Translator|MockObject */
+    private $translateClientMock;
+
+    /** @var DeeplTranslator */
+    private $deeplTranslator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['config']->set('translator.translators.deepl', [
+            'api_key' => 'test-key',
+        ]);
+
+        $this->translateClientMock = $this->createMock(Translator::class);
+        $this->variableHandlerMock = $this->createMock(VariableRegexHandler::class);
+        $this->deeplTranslator = new DeeplTranslator($this->variableHandlerMock, $this->translateClientMock);
+    }
+
+    #[Test]
+    public function translate(): void
+    {
+        $text = 'Hello, world!';
+        $translatedText = 'Bonjour le monde!';
+        $targetLanguage = 'fr';
+
+        $this->variableHandlerMock->method('replacePlaceholders')
+            ->willReturn($text);
+
+        $this->variableHandlerMock->method('restorePlaceholders')
+            ->willReturn($translatedText);
+
+        $this->translateClientMock->method('translateText')
+            ->willReturn(new TextResult($translatedText, 'en', 0));
+
+        $result = $this->deeplTranslator->translate($text, $targetLanguage);
+
+        $this->assertSame($translatedText, $result);
+    }
+
+    #[Test]
+    public function translateBatch(): void
+    {
+        $texts = ['Hello, world!', 'Good morning'];
+        $translatedTexts = ['Bonjour le monde!', 'Bonjour'];
+        $targetLanguage = 'fr';
+
+        $translations = array_map(fn ($text) => new TextResult($text, 'en', 0), $translatedTexts);
+
+        $this->variableHandlerMock->expects($this->exactly(count($texts)))
+            ->method('replacePlaceholders')
+            ->willReturnOnConsecutiveCalls(...$texts);
+
+        $this->variableHandlerMock->expects($this->exactly(count($texts)))
+            ->method('restorePlaceholders')
+            ->willReturnOnConsecutiveCalls(...$translatedTexts);
+
+        $this->translateClientMock->expects($this->once())
+            ->method('translateText')
+            ->willReturn($translations);
+
+        $result = $this->deeplTranslator->translateBatch($texts, $targetLanguage);
+
+        $this->assertSame(['Hello, world!' => 'Bonjour le monde!', 'Good morning' => 'Bonjour'], $result);
+    }
+
+    #[Test]
+    public function testDeeplTranslatorBinding(): void
+    {
+        $this->assertInstanceOf(DeeplTranslator::class, app(DeeplTranslator::class));
+    }
+
+    #[Test]
+    public function testDeeplTranslatorHasValidCredentials(): void
+    {
+        $this->assertTrue($this->deeplTranslator->isConfigured());
+        ;
+    }
+
+    #[Test]
+    public function testDeeplTranslatorHasInvalidCredentials(): void
+    {
+        $this->app['config']->set('translator.translators.deepl', [
+            'api_key' => null,
+        ]);
+        $this->assertFalse($this->deeplTranslator->isConfigured());
+        ;
+    }
+}


### PR DESCRIPTION
Hi 👋 

Nice package! 

I figured it would be nice to also include DeepL as a translation service. This will give an opportunity to the privacy focused people an alternative to OpenAI and Google Translate.

I’m marking the PR as a draft since I want to test the integration in a real Laravel app before I mark the PR as done.