### PR TITLE
Sort language files in tests

### DIFF
--- a/tests/File/Language/LanguageDirectoryManagerTest.php
+++ b/tests/File/Language/LanguageDirectoryManagerTest.php
@@ -5,6 +5,7 @@ namespace Bottelet\TranslationChecker\Tests\File\Language;
 use Bottelet\TranslationChecker\File\Language\LanguageDirectoryManager;
 use Bottelet\TranslationChecker\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use SplFileInfo;
 
 class LanguageDirectoryManagerTest extends TestCase
 {
@@ -26,6 +27,10 @@ class LanguageDirectoryManagerTest extends TestCase
     public function getAllLanguageFiles(): void
     {
         $files = $this->directoryManager->getLanguageFiles();
+
+        usort($files, function (SplFileInfo $a, SplFileInfo $b) {
+            return strcmp($a->getFilename(), $b->getFilename());
+        });
 
         $this->assertCount(2, $files);
         $this->assertEquals($this->translationFile, $files[0]->getPathname());


### PR DESCRIPTION
Avoids random retrieval of testfiles

Concrete:
```
Bottelet\TranslationChecker\Tests\File\Language\LanguageDirectoryManagerTest::getAllLanguageFiles
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/tmp/bottelet-translation-checker-test/lang/da.json'
+'/tmp/bottelet-translation-checker-test/lang/fr.json'

translation-checker/tests/File/Language/LanguageDirectoryManagerTest.php:32
```