### PR TITLE
fix DeepL translation service doc page

### DIFF
--- a/docs/translation-services/deepl.md
+++ b/docs/translation-services/deepl.md
@@ -1,3 +1,10 @@
+---
+title: DeepL
+layout: default
+parent: Translation Services
+nav_order: 3
+---
+
 For DeepL, you need to set the following environment variable
 ```bash
 DEEPL_API_KEY=your_api_key


### PR DESCRIPTION
The DeepL documentation page was missing the proper page configuration, thus wasn’t displayed.