### PR TITLE
Add check for 'name' property to prevent errors in Blade extraction

### DIFF
--- a/src/Extractor/BladeFileExtractor.php
+++ b/src/Extractor/BladeFileExtractor.php
@@ -27,8 +27,7 @@ class BladeFileExtractor extends PhpBaseClassExtractor
             $variable = $node->var;
             /** @var Name $function */
             $function = $variable->name;
-
-            if ($function->name === 'app') {
+            if (property_exists($function, 'name') && $function->name === 'app') {
                 /** @var Node\Arg $argument */
                 $argument = $variable->getArgs()[0];
                 /** @var Node\Scalar\String_ $value */

--- a/tests/Extractors/BladeFileExtractorTest.php
+++ b/tests/Extractors/BladeFileExtractorTest.php
@@ -95,4 +95,22 @@ class BladeFileExtractorTest extends TestCase
 
         $this->assertNull($result);
     }
+
+    #[Test]
+    public function willIgnoreGetMethodIfNodeHasNoNameProperty():void
+    {
+        $code = <<<'BLADE'
+                <div>
+                    @if ($request->get('version') === "1.0")
+                        {{ __('Complete registration') }}
+                    @endif
+                </div>
+BLADE;
+
+        $file = $this->createTempFile('node-without-name-prop.blade.php', $code);
+        $phpExtractor = new BladeFileExtractor;
+        $foundStrings = $phpExtractor->extractFromFile($file);
+
+        $this->assertContains('Complete registration', $foundStrings);
+    }
 }


### PR DESCRIPTION
Resolves:

```
RuntimeException: Error parsing file /tmp/bottelet-translation-checker-test/node-without-name-prop.blade.php: Attempt to read property "name" on string
``` 