### PR TITLE
feat: implement free Google translation service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "nikic/php-parser": "^v5.2",
         "google/cloud-translate": "^1.17",
         "openai-php/client": "^0.10.1",
-        "deeplcom/deepl-php": "^1.9"
+        "deeplcom/deepl-php": "^1.9",
+        "stichoza/google-translate-php": "^5.2"
     },
     "scripts": {
         "test": "vendor/bin/phpunit tests"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7939a7b956d5a31121e191f5aebdc1ea",
+    "content-hash": "5495b74742400dc11f8c495cf182aa2c",
     "packages": [
         {
             "name": "brick/math",
@@ -1923,6 +1923,87 @@
                 }
             ],
             "time": "2024-08-30T07:09:40+00:00"
+        },
+        {
+            "name": "stichoza/google-translate-php",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Stichoza/google-translate-php.git",
+                "reference": "9429773d991c98f68a25bec40d20f590ea3312a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Stichoza/google-translate-php/zipball/9429773d991c98f68a25bec40d20f590ea3312a0",
+                "reference": "9429773d991c98f68a25bec40d20f590ea3312a0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/guzzle": "^7.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Stichoza\\GoogleTranslate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Levan Velijanashvili",
+                    "email": "me@stichoza.com"
+                }
+            ],
+            "description": "Free Google Translate API PHP Package",
+            "homepage": "https://github.com/Stichoza/google-translate-php",
+            "keywords": [
+                "google",
+                "php",
+                "translate",
+                "translating",
+                "translator"
+            ],
+            "support": {
+                "issues": "https://github.com/Stichoza/google-translate-php/issues",
+                "source": "https://github.com/Stichoza/google-translate-php/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://btc.com/bc1qc25j4x7yahghm8nnn6lypnw59nptylsw32nkfl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/stichoza",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://ko-fi.com/stichoza",
+                    "type": "ko_fi"
+                },
+                {
+                    "url": "https://liberapay.com/stichoza",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://opencollective.com/stichoza",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/stichoza",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-08-05T19:11:36+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/config/translator.php
+++ b/config/translator.php
@@ -13,8 +13,11 @@ return [
       | Supported: "google", "openai", "deepl"
       |
       */
-    'default' => env('DEFAULT_TRANSLATOR_SERVICE', 'openai'),
+    'default' => env('DEFAULT_TRANSLATOR_SERVICE', 'free_google'),
     'translators' => [
+        'free_google' => [
+            'driver' => Bottelet\TranslationChecker\Translator\FreeGoogleTranslator::class,
+        ],
         'google' => [
             'driver' => Bottelet\TranslationChecker\Translator\GoogleTranslator::class,
             'type' => env('GOOGLE_TRANSLATE_TYPE', 'service_account'),
@@ -39,6 +42,14 @@ return [
         base_path('resources/'),
     ],
     'language_folder' => base_path('/lang'),
+
+    /**
+     *  Specify a PHP filename if you prefer not to use JSON files like en.json
+     *
+     *  This approach offers several advantages for developers, as PHP translation files are often more manageable
+     *  and compatible with translation UIs, such as [https://github.com/MohmmedAshraf/laravel-translations].
+     */
+    'php_file_name' => '', // add `msg`, `message`, `label`, etc
 
     /**
      * Defines the function used to mark strings for translation without actually translating them.

--- a/config/translator.php
+++ b/config/translator.php
@@ -44,14 +44,6 @@ return [
     'language_folder' => base_path('/lang'),
 
     /**
-     *  Specify a PHP filename if you prefer not to use JSON files like en.json
-     *
-     *  This approach offers several advantages for developers, as PHP translation files are often more manageable
-     *  and compatible with translation UIs, such as [https://github.com/MohmmedAshraf/laravel-translations].
-     */
-    'php_file_name' => '', // add `msg`, `message`, `label`, etc
-
-    /**
      * Defines the function used to mark strings for translation without actually translating them.
      *
      * When this function (e.g., '__t') is used, it returns the original string unchanged. This is useful

--- a/docs/translation-services/free-google.md
+++ b/docs/translation-services/free-google.md
@@ -1,0 +1,12 @@
+---
+title: Free Google
+layout: default
+parent: Translation Services
+nav_order: 0
+---
+
+# Google Translation API
+
+Access Google Translate free of charge, without needing to set up API keys.
+
+Based on this [powerful package](https://github.com/Stichoza/google-translate-php)

--- a/docs/translation-services/google.md
+++ b/docs/translation-services/google.md
@@ -5,9 +5,11 @@ parent: Translation Services
 nav_order: 1
 ---
 
-# Google Translation API
+# Google Cloud Translation API
 
-For Google Translate, you need to set the following environment variables
+For Google Cloud Translate (More advanced translation than free Google previously), you need to set the following
+environment variables
+
 ```bash
 GOOGLE_TRANSLATE_TYPE=service_account
 GOOGLE_TRANSLATE_PROJECT_ID=your_project_id

--- a/src/TranslationCheckerServiceProvider.php
+++ b/src/TranslationCheckerServiceProvider.php
@@ -5,6 +5,7 @@ namespace Bottelet\TranslationChecker;
 use Bottelet\TranslationChecker\Sort\AlphabeticSort;
 use Bottelet\TranslationChecker\Sort\SorterContract;
 use Bottelet\TranslationChecker\Translator\DeeplTranslator;
+use Bottelet\TranslationChecker\Translator\FreeGoogleTranslator;
 use Bottelet\TranslationChecker\Translator\GoogleTranslator;
 use Bottelet\TranslationChecker\Translator\OpenAiTranslator;
 use Bottelet\TranslationChecker\Translator\TranslatorContract;
@@ -34,6 +35,13 @@ class TranslationCheckerServiceProvider extends ServiceProvider
             return new GoogleTranslator(
                 $app->make(VariableRegexHandler::class),
                 new TranslateClient(['keyFile' =>  $app->config['translator.translators.google']])
+            );
+        });
+
+        $this->app->bind(FreeGoogleTranslator::class, function ($app) {
+            return new FreeGoogleTranslator(
+                $app->make(VariableRegexHandler::class),
+                new \Stichoza\GoogleTranslate\GoogleTranslate()
             );
         });
 

--- a/src/Translator/FreeGoogleTranslator.php
+++ b/src/Translator/FreeGoogleTranslator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Bottelet\TranslationChecker\Translator;
+
+use Bottelet\TranslationChecker\Translator\VariableHandlers\VariableRegexHandler;
+use Stichoza\GoogleTranslate\Exceptions\LargeTextException;
+use Stichoza\GoogleTranslate\Exceptions\RateLimitException;
+use Stichoza\GoogleTranslate\Exceptions\TranslationRequestException;
+use Stichoza\GoogleTranslate\GoogleTranslate;
+
+class FreeGoogleTranslator implements TranslatorContract
+{
+    public function __construct(
+        protected VariableRegexHandler $variableHandler,
+        protected GoogleTranslate      $translateClient,
+    ) {
+    }
+
+    /**
+     * @throws LargeTextException
+     * @throws RateLimitException
+     * @throws TranslationRequestException
+     */
+    public function translate(string $text, string $targetLanguage, string $sourceLanguage = 'en'): string
+    {
+        $replaceVariablesText = $this->variableHandler->replacePlaceholders($text);
+
+        $translation = $this->translateClient
+            ->setSource($sourceLanguage)
+            ->setTarget($targetLanguage)
+            ->translate($replaceVariablesText);
+
+        if (!isset($translation)) {
+            return '';
+        }
+
+        return $this->variableHandler->restorePlaceholders($translation);
+    }
+
+    /**
+     * @param array<string> $texts Array of texts to translate.
+     * @param string $targetLanguage
+     * @param string $sourceLanguage
+     * @return array<string, string> Array of translated texts.
+     *
+     * @throws LargeTextException
+     * @throws RateLimitException
+     * @throws TranslationRequestException
+     */
+    public function translateBatch(array $texts, string $targetLanguage, string $sourceLanguage = 'en'): array
+    {
+        $textsToTranslate = array_map([$this->variableHandler, 'replacePlaceholders'], $texts);
+
+        $translations = [];
+        foreach ($textsToTranslate as $text) {
+            $translations[] = $this->translateClient
+                ->setSource($sourceLanguage)
+                ->setTarget($targetLanguage)
+                ->translate($text);
+        }
+
+        $translatedKeys = [];
+        foreach ($translations as $index => $translation) {
+            $translatedText = $translation ? $this->variableHandler->restorePlaceholders($translation) : '';
+            $translatedKeys[$texts[$index]] = $translatedText;
+        }
+
+        return $translatedKeys;
+    }
+
+    public function isConfigured(): bool
+    {
+        /** @var array<string, null|string> $freeGoogleConfig */
+        $freeGoogleConfig = config('translator.translators.free_google');
+
+        return !in_array(null, $freeGoogleConfig, true);
+    }
+}

--- a/tests/Translator/FreeGoogleTranslatorTest.php
+++ b/tests/Translator/FreeGoogleTranslatorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Bottelet\TranslationChecker\Tests\Translator;
+
+use Bottelet\TranslationChecker\Translator\FreeGoogleTranslator;
+use Bottelet\TranslationChecker\Translator\GoogleTranslator;
+use Bottelet\TranslationChecker\Translator\VariableHandlers\VariableRegexHandler;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class FreeGoogleTranslatorTest extends \Bottelet\TranslationChecker\Tests\TestCase
+{
+    /** @var VariableRegexHandler|MockObject */
+    private $variableHandlerMock;
+
+    /** @var \Stichoza\GoogleTranslate\GoogleTranslate|MockObject */
+    private $translateClientMock;
+
+    /** @var FreeGoogleTranslator */
+    private $freeGoogleTranslator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->translateClientMock = $this->createMock(\Stichoza\GoogleTranslate\GoogleTranslate::class);
+        $this->variableHandlerMock = $this->createMock(VariableRegexHandler::class);
+        $this->freeGoogleTranslator = new FreeGoogleTranslator($this->variableHandlerMock, $this->translateClientMock);
+    }
+
+    #[Test]
+    public function freeGoogleTranslateIfTextKeyNotReturned(): void
+    {
+        $this->translateClientMock->method('translate')->willReturn(null);
+
+        $this->variableHandlerMock->method('restorePlaceholders')->willReturn('Translated text');
+
+        $result = $this->freeGoogleTranslator->translate('Hello', 'fr', 'en');
+
+        $this->assertEquals('', $result);
+    }
+
+    #[Test]
+    public function translate(): void
+    {
+        $text = 'Hello, world!';
+        $translatedText = 'Bonjour le monde!';
+        $targetLanguage = 'fr';
+
+        $this->variableHandlerMock
+            ->method('replacePlaceholders')
+            ->willReturn($text);
+
+        $this->variableHandlerMock
+            ->method('restorePlaceholders')
+            ->willReturn($translatedText);
+
+        $this->translateClientMock
+            ->method('setSource')
+            ->with('en')
+            ->willReturn($this->translateClientMock);
+
+        $this->translateClientMock
+            ->method('setTarget')
+            ->with($targetLanguage)
+            ->willReturn($this->translateClientMock);
+
+        $this->translateClientMock
+            ->method('translate')
+            ->with($text)
+            ->willReturn($translatedText);
+
+        $result = $this->freeGoogleTranslator->translate($text, $targetLanguage);
+
+        $this->assertSame($translatedText, $result);
+    }
+
+    #[Test]
+    public function translateBatch(): void
+    {
+        $texts = ['Hello, world!', 'Good morning'];
+        $translatedTexts = ['Bonjour le monde!', 'Bonjour'];
+        $targetLanguage = 'fr';
+        $sourceLanguage = 'en';
+
+        $this->variableHandlerMock
+            ->expects($this->exactly(count($texts)))
+            ->method('replacePlaceholders')
+            ->willReturnArgument(0);
+
+        $this->variableHandlerMock
+            ->expects($this->exactly(count($texts)))
+            ->method('restorePlaceholders')
+            ->willReturnArgument(0);
+
+        $this->translateClientMock
+            ->expects($this->exactly(count($texts)))
+            ->method('setSource')
+            ->with($sourceLanguage)
+            ->willReturnSelf();
+
+        $this->translateClientMock
+            ->expects($this->exactly(count($texts)))
+            ->method('setTarget')
+            ->with($targetLanguage)
+            ->willReturnSelf();
+
+        $this->translateClientMock->expects($this->exactly(count($texts)))
+            ->method('translate')
+            ->willReturnOnConsecutiveCalls(...$translatedTexts);
+
+        $result = $this->freeGoogleTranslator->translateBatch($texts, $targetLanguage, $sourceLanguage);
+
+        $this->assertSame(
+            [
+            'Hello, world!' => 'Bonjour le monde!',
+            'Good morning' => 'Bonjour'],
+            $result
+        );
+    }
+
+    #[Test]
+    public function testGoogleTranslatorBinding(): void
+    {
+        $this->assertInstanceOf(GoogleTranslator::class, app(GoogleTranslator::class));
+    }
+
+    #[Test]
+    public function testGoogleTranslatorHasValidCredentials(): void
+    {
+        $this->assertTrue($this->freeGoogleTranslator->isConfigured());
+    }
+}


### PR DESCRIPTION
I have added in this pull request the free Google translation services without any keys, and made it the default because it is free and require nothing. Users can change their service with paid one (or required API keys).

I have also written the corresponding text and documentation for this service.


I hope you merge it.


 

