### PR TITLE
✨ [Feature] Add nested translation support via --nested flag

### DIFF
--- a/src/Commands/CheckTranslation.php
+++ b/src/Commands/CheckTranslation.php
@@ -10,7 +10,8 @@ class CheckTranslation extends BaseTranslationCommand
                             {target : The target language for the translations}
                             {--source= : The source language used for the translation provider}
                             {--translate-missing : Translate missing translations using the translation service}
-                            {--sort : Sort JSON translation files}';
+                            {--sort : Sort JSON translation files}
+                            {--nested : Use nested structure where keys are split at the first dot}';
 
     protected $description = 'Check and manage translations';
 
@@ -28,8 +29,10 @@ class CheckTranslation extends BaseTranslationCommand
             $options->sort,
             $options->target,
             $options->translateMissing,
-            $options->source
+            $options->source,
+            $options->nested
         );
+
         $this->displayResult($missingTranslations);
     }
 
@@ -39,7 +42,8 @@ class CheckTranslation extends BaseTranslationCommand
             source: is_string($this->option('source')) ? $this->option('source') : 'en',
             target: is_string($this->argument('target')) ? $this->argument('target') : 'en',
             translateMissing: (bool) $this->option('translate-missing'),
-            sort: (bool) $this->option('sort')
+            sort: (bool) $this->option('sort'),
+            nested: (bool) $this->option('nested')
         );
     }
 

--- a/src/Commands/CleanTranslation.php
+++ b/src/Commands/CleanTranslation.php
@@ -36,9 +36,10 @@ class CleanTranslation extends BaseTranslationCommand
 
         if ($options->nested) {
             $this->cleanNestedTranslations($usedTranslations, $options->source, $options->print);
-        } else {
-            $this->cleanSingleFileTranslations($usedTranslations, $sourceJsonPath, $options->print);
+            return;
         }
+
+        $this->cleanSingleFileTranslations($usedTranslations, $sourceJsonPath, $options->print);
     }
 
     protected function cleanSingleFileTranslations(array $usedTranslations, string $sourceJsonPath, bool $print = true): void
@@ -83,8 +84,8 @@ class CleanTranslation extends BaseTranslationCommand
     {
         return new CommandOptions(
             source: is_string($this->option('source')) ? $this->option('source') : 'en',
-            print: (bool) $this->option('print'),
-            nested: (bool) $this->option('nested')
+            print: (bool)$this->option('print'),
+            nested: (bool)$this->option('nested')
         );
     }
 

--- a/src/Commands/CleanTranslation.php
+++ b/src/Commands/CleanTranslation.php
@@ -4,6 +4,7 @@ namespace Bottelet\TranslationChecker\Commands;
 
 use Bottelet\TranslationChecker\File\FileManagement;
 use Bottelet\TranslationChecker\File\Language\LanguageFileManagerFactory;
+use Bottelet\TranslationChecker\File\Language\PhpNestedLanguageFileHelper;
 use Bottelet\TranslationChecker\Finder\MissingKeysFinder;
 use Bottelet\TranslationChecker\Finder\TranslationFinder;
 
@@ -11,7 +12,8 @@ class CleanTranslation extends BaseTranslationCommand
 {
     protected $signature = 'translations:clean
                             {--source= : The source language for the translations to clean}
-                            {--print : Print the cleaned translations to the console, instead of updating the file}';
+                            {--print : Print the cleaned translations to the console, instead of updating the file}
+                            {--nested : Use nested structure where keys are split at the first dot}';
 
     protected $description = 'Clean translations by removing unused keys from the source language file';
 
@@ -29,34 +31,71 @@ class CleanTranslation extends BaseTranslationCommand
             new MissingKeysFinder()
         );
 
-        $missingTranslations = $translationFinder->findAllTranslations($sourceFilePaths)->getKeys();
+        // Get all used keys from source files
+        $usedTranslations = $translationFinder->findAllTranslations($sourceFilePaths)->getKeys();
+
+        if ($options->nested) {
+            $this->cleanNestedTranslations($usedTranslations, $options->source, $options->print);
+        } else {
+            $this->cleanSingleFileTranslations($usedTranslations, $sourceJsonPath, $options->print);
+        }
+    }
+
+    protected function cleanSingleFileTranslations(array $usedTranslations, string $sourceJsonPath, bool $print = true): void
+    {
         $sourceFileManager = new LanguageFileManagerFactory($sourceJsonPath);
         $sourceTranslations = $sourceFileManager->readFile();
 
-        $cleanedTranslations = array_intersect_key($sourceTranslations, $missingTranslations);
-        if ($options->print) {
+        $cleanedTranslations = array_intersect_key($sourceTranslations, $usedTranslations);
+
+        if ($print) {
             $this->printTranslations($cleanedTranslations);
         } else {
             $sourceFileManager->updateFile($cleanedTranslations);
-            $this->info('Unused translations removed from the source language file.');
         }
+    }
+
+    protected function cleanNestedTranslations(array $usedTranslations, string $language, bool $print = true): void
+    {
+        $existingTranslations = PhpNestedLanguageFileHelper::getAllNestedTranslations($language);
+
+        $kept = array_intersect_key($existingTranslations, $usedTranslations);
+        $removed = array_diff_key($existingTranslations, $usedTranslations);
+
+        if ($print) {
+            $this->printTranslations($kept, 'Kept');
+            $this->printTranslations($removed, 'Removed');
+
+            return;
+        }
+
+        $translationsToKeep = PhpNestedLanguageFileHelper::processNestedKeys($kept);
+
+        PhpNestedLanguageFileHelper::cleanNestedTranslations(
+            $translationsToKeep,
+            $language
+        );
+
+        $this->printTranslations($removed, 'Removed');
     }
 
     protected function parseOptions(): CommandOptions
     {
         return new CommandOptions(
             source: is_string($this->option('source')) ? $this->option('source') : 'en',
-            print: (bool) $this->option('print')
+            print: (bool) $this->option('print'),
+            nested: (bool) $this->option('nested')
         );
     }
 
     /**
      * @param array<string, string> $translations
      */
-    private function printTranslations(array $translations): void
+    private function printTranslations(array $translations, string $message = ''): void
     {
+        $this->info("\n=== $message (" . count($translations) . ') ===');
         foreach ($translations as $key => $value) {
-            $this->line("Key: {$key}, Value: {$value}");
+            $this->line("$key: " . (is_array($value) ? json_encode($value) : $value));
         }
     }
 }

--- a/src/Commands/CommandOptions.php
+++ b/src/Commands/CommandOptions.php
@@ -7,10 +7,12 @@ final class CommandOptions
     public function __construct(
         public readonly string $source = 'en',
         public readonly string $target = '',
-        public readonly bool $translateMissing = false,
-        public readonly bool $sort = false,
-        public readonly bool $print = false,
-        public readonly bool $all = false
-    ) {
+        public readonly bool   $translateMissing = false,
+        public readonly bool   $sort = false,
+        public readonly bool   $print = false,
+        public readonly bool   $all = false,
+        public readonly bool   $nested = false
+    )
+    {
     }
 }

--- a/src/File/Language/PhpNestedLanguageFileHelper.php
+++ b/src/File/Language/PhpNestedLanguageFileHelper.php
@@ -4,6 +4,9 @@ namespace Bottelet\TranslationChecker\File\Language;
 
 class PhpNestedLanguageFileHelper
 {
+    //TODO this should be moved to config to avoid possible conflicts
+    public const GENERAL_TRANSLATION_FILE_NAME = 'general';
+
     public static function processNestedKeys(array $translations): array
     {
         $nestedTranslations = [];
@@ -19,29 +22,52 @@ class PhpNestedLanguageFileHelper
                 $nestedTranslations[$fileKey][$remainingKey] = $value;
             } else {
                 // Use 'general' for keys without dots
-                if (!isset($nestedTranslations['general'])) {
-                    $nestedTranslations['general'] = [];
-                }
-                $nestedTranslations['general'][$key] = $value;
+                $nestedTranslations[self::GENERAL_TRANSLATION_FILE_NAME][$key] = $value;
             }
         }
 
         return $nestedTranslations;
     }
 
-    public static function writeNestedTranslations(array $nestedTranslations, string $languageFolder, string $language): void
+    public static function getAllNestedTranslations(string $language): array
     {
-        $languageDir = rtrim($languageFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $language;
+        $languageDir = self::getLanguageDir($language);
+
+        // Get all existing translations from nested files
+        $existingTranslations = [];
+        $phpFiles = glob($languageDir . DIRECTORY_SEPARATOR . '*.php');
+
+        foreach ($phpFiles as $phpFile) {
+            $filename = pathinfo($phpFile, PATHINFO_FILENAME);
+            $fileTranslations = require $phpFile;
+
+            if (is_array($fileTranslations)) {
+                // Convert nested keys to dot notation to match used keys format
+                foreach ($fileTranslations as $key => $value) {
+                    $fullKey = $filename . '.' . $key;
+                    $existingTranslations[$fullKey] = $value;
+                }
+            }
+        }
+
+        return $existingTranslations;
+    }
+
+    public static function writeNestedTranslations(array $nestedTranslations, string $language): void
+    {
+        $languageDir = self::getLanguageDir($language);
+
+        // Ensure language directory exists
         if (!file_exists($languageDir)) {
             mkdir($languageDir, 0755, true);
         }
 
         foreach ($nestedTranslations as $file => $translations) {
-            if (empty($translations)) {
-                continue;
-            }
-
             $filePath = $languageDir . DIRECTORY_SEPARATOR . $file . '.php';
+            $fileDir = dirname($filePath);
+            if (!file_exists($fileDir)) {
+                mkdir($fileDir, 0755, true);
+            }
 
             $existingTranslations = [];
             if (file_exists($filePath)) {
@@ -58,5 +84,35 @@ class PhpNestedLanguageFileHelper
 
             file_put_contents($filePath, "<?php\n\nreturn " . var_export($translations, true) . ";\n");
         }
+    }
+
+    public static function cleanNestedTranslations(array $nestedTranslationsToKeep, string $language): void
+    {
+        $languageDir = self::getLanguageDir($language);
+
+        foreach ($nestedTranslationsToKeep as $file => $translations) {
+            $filePath = $languageDir . DIRECTORY_SEPARATOR . $file . '.php';
+            file_put_contents($filePath, "<?php\n\nreturn " . var_export($translations, true) . ";\n");
+        }
+
+        // Delete files that aren't needed anymore
+        $filesToKeep = array_map(
+            fn ($file) => $languageDir . DIRECTORY_SEPARATOR . $file . '.php',
+            array_keys($nestedTranslationsToKeep)
+        );
+
+        // Get all existing PHP files in the language directory
+        $phpFiles = glob($languageDir . DIRECTORY_SEPARATOR . '*.php');
+        foreach ($phpFiles as $phpFile) {
+            if (!in_array($phpFile, $filesToKeep)) {
+                //delete empty files
+                @unlink($phpFile);
+            }
+        }
+    }
+
+    private static function getLanguageDir(string $language): string
+    {
+        return rtrim(config('translator.language_folder'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $language;
     }
 }

--- a/src/File/Language/PhpNestedLanguageFileHelper.php
+++ b/src/File/Language/PhpNestedLanguageFileHelper.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Bottelet\TranslationChecker\File\Language;
+
+class PhpNestedLanguageFileHelper
+{
+    public static function processNestedKeys(array $translations): array
+    {
+        $nestedTranslations = [];
+
+        foreach ($translations as $key => $value) {
+            if (str_contains($key, '.')) {
+                list($fileKey, $remainingKey) = explode('.', $key, 2);
+
+                if (!isset($nestedTranslations[$fileKey])) {
+                    $nestedTranslations[$fileKey] = [];
+                }
+
+                $nestedTranslations[$fileKey][$remainingKey] = $value;
+            } else {
+                // Use 'general' for keys without dots
+                if (!isset($nestedTranslations['general'])) {
+                    $nestedTranslations['general'] = [];
+                }
+                $nestedTranslations['general'][$key] = $value;
+            }
+        }
+
+        return $nestedTranslations;
+    }
+
+    public static function writeNestedTranslations(array $nestedTranslations, string $languageFolder, string $language): void
+    {
+        $languageDir = rtrim($languageFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $language;
+        if (!file_exists($languageDir)) {
+            mkdir($languageDir, 0755, true);
+        }
+
+        foreach ($nestedTranslations as $file => $translations) {
+            if (empty($translations)) {
+                continue;
+            }
+
+            $filePath = $languageDir . DIRECTORY_SEPARATOR . $file . '.php';
+
+            $existingTranslations = [];
+            if (file_exists($filePath)) {
+                $existingTranslations = require $filePath;
+                if (is_array($existingTranslations)) {
+                    foreach ($translations as $key => $value) {
+                        if (!isset($existingTranslations[$key]) || $value !== null) {
+                            $existingTranslations[$key] = $value;
+                        }
+                    }
+                    $translations = $existingTranslations;
+                }
+            }
+
+            file_put_contents($filePath, "<?php\n\nreturn " . var_export($translations, true) . ";\n");
+        }
+    }
+}

--- a/src/TranslationManager.php
+++ b/src/TranslationManager.php
@@ -69,8 +69,6 @@ class TranslationManager
         }
 
         $nestedTranslations = PhpNestedLanguageFileHelper::processNestedKeys($translations);
-        $languageFolder = config('translator.language_folder');
-
-        PhpNestedLanguageFileHelper::writeNestedTranslations($nestedTranslations, $languageFolder, $language);
+        PhpNestedLanguageFileHelper::writeNestedTranslations($nestedTranslations, $language);
     }
 }

--- a/tests/Commands/CleanTranslationTest.php
+++ b/tests/Commands/CleanTranslationTest.php
@@ -3,6 +3,7 @@
 namespace Bottelet\TranslationChecker\Tests\Commands;
 
 use Bottelet\TranslationChecker\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -19,7 +20,7 @@ class CleanTranslationTest extends TestCase
         ]);
 
         Config::set('translator.source_paths', [$this->tempDir]);
-        Config::set('translator.language_folder', $this->tempDir.'/lang');
+        Config::set('translator.language_folder', $this->tempDir . '/lang');
     }
 
     #[Test]
@@ -89,5 +90,62 @@ class CleanTranslationTest extends TestCase
 
         $content = json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
         $this->assertEmpty($content);
+    }
+
+    #[Test]
+    public function itCleanNestedTranslationsCorrectly(): void
+    {
+        file_put_contents($this->tempDir . '/controller.php', '<?php 
+        echo __("home.welcome");
+        echo __("admin.users.list");
+        ?>');
+
+        // Set up all nested translation files with existing values
+        $this->createNestedTranslationFile('en', 'home', [
+            'welcome' => 'Welcome to our home',
+            'unused_key' => 'This should be removed',
+            'another_unused' => 'Also should be removed',
+        ]);
+
+        $this->createNestedTranslationFile('en', 'admin', [
+            'users.list' => 'User List',
+            'users.create' => 'Create User', // Should be removed (unused)
+            'settings' => 'Settings', // Should be removed (unused)
+        ]);
+
+        $this->createNestedTranslationFile('en', 'dashboard', [
+            'analytics.visits' => 'Visits', // Should be removed (entire file, unused)
+            'analytics.users' => 'Users',
+        ]);
+
+        $this->createNestedTranslationFile('en', 'general', [
+            'simple' => 'Simple value', // Should be removed (entire file, unused)
+        ]);
+
+        // Run clean with nested flag
+        Artisan::call('translations:clean', [
+            '--source' => 'en',
+            '--nested' => true,
+        ]);
+
+        // Check that used translations still exist
+        $this->assertNestedFileContains('en', 'home', ['welcome' => 'Welcome to our home']);
+        $this->assertNestedFileContains('en', 'admin', ['users.list' => 'User List']);
+
+        // Check that unused keys were removed
+        $homeFile = require $this->tempDir . '/lang/en/home.php';
+        $this->assertArrayNotHasKey('unused_key', $homeFile);
+        $this->assertArrayNotHasKey('another_unused', $homeFile);
+
+        $adminFile = require $this->tempDir . '/lang/en/admin.php';
+        $this->assertArrayNotHasKey('users.create', $adminFile);
+        $this->assertArrayNotHasKey('settings', $adminFile);
+
+        // Check that unused translation files were removed
+        $dashboardFilePath = $this->tempDir . '/lang/en/dashboard.php';
+        $this->assertFileDoesNotExist($dashboardFilePath);
+
+        $generalFilePath = $this->tempDir . '/lang/en/general.php';
+        $this->assertFileDoesNotExist($generalFilePath);
     }
 }

--- a/tests/Commands/SortTranslationTest.php
+++ b/tests/Commands/SortTranslationTest.php
@@ -3,6 +3,7 @@
 namespace Bottelet\TranslationChecker\Tests\Commands;
 
 use Bottelet\TranslationChecker\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -22,7 +23,7 @@ class SortTranslationTest extends TestCase
             'd' => 'value',
         ]);
 
-        Config::set('translator.language_folder', $this->tempDir.'/lang');
+        Config::set('translator.language_folder', $this->tempDir . '/lang');
     }
 
     #[Test]
@@ -84,5 +85,99 @@ class SortTranslationTest extends TestCase
 
         $this->assertSame($expectedContentDaFile, $sortedContentDaFile);
         $this->assertSame($expectedContentEsFile, $sortedContentEsFile);
+    }
+
+    #[Test]
+    public function itSortsNestedPhpFiles(): void
+    {
+        // Create unsorted nested PHP translation files directly
+        $this->createNestedTranslationFile('nl', 'home', [
+            'zitem' => 'Z Item NL',
+            'aitem' => 'A Item NL',
+            'citem' => 'C Item NL',
+            'bitem' => 'B Item NL',
+        ]);
+
+        $this->createNestedTranslationFile('nl', 'dashboard', [
+            'zmetric' => 'Z Metric NL',
+            'ametric' => 'A Metric NL',
+            'cmetric' => 'C Metric NL',
+            'bmetric' => 'B Metric NL',
+        ]);
+
+        $this->createNestedTranslationFile('nl', 'general', [
+            'zsimple' => 'Z Simple NL',
+            'asimple' => 'A Simple NL',
+        ]);
+
+        // Run sort with nested flag
+        Artisan::call('translations:sort', [
+            '--source' => 'nl',
+            '--nested' => true,
+        ]);
+
+        // Verify PHP files are sorted alphabetically
+        $this->assertNestedFileSorted('nl', 'home');
+        $this->assertNestedFileSorted('nl', 'dashboard');
+        $this->assertNestedFileSorted('nl', 'general');
+
+        // Verify content is preserved
+        $expectedHomeContents = [
+            'aitem' => 'A Item NL',
+            'bitem' => 'B Item NL',
+            'citem' => 'C Item NL',
+            'zitem' => 'Z Item NL',
+        ];
+        $this->assertNestedFileContains('nl', 'home', $expectedHomeContents);
+
+        $expectedDashboardContents = [
+            'ametric' => 'A Metric NL',
+            'bmetric' => 'B Metric NL',
+            'cmetric' => 'C Metric NL',
+            'zmetric' => 'Z Metric NL',
+        ];
+        $this->assertNestedFileContains('nl', 'dashboard', $expectedDashboardContents);
+
+        $expectedGeneralContents = [
+            'asimple' => 'A Simple NL',
+            'zsimple' => 'Z Simple NL',
+        ];
+        $this->assertNestedFileContains('nl', 'general', $expectedGeneralContents);
+    }
+
+    #[Test]
+    public function itSortsNestedPhpFilesWithAllOption(): void
+    {
+        // Create unsorted nested PHP translation files for multiple languages
+        $this->createNestedTranslationFile('fr', 'home', [
+            'zitem' => 'Z Item FR',
+            'aitem' => 'A Item FR',
+        ]);
+
+        $this->createNestedTranslationFile('it', 'dashboard', [
+            'zmetric' => 'Z Metric IT',
+            'ametric' => 'A Metric IT',
+        ]);
+
+        // Run sort with nested and all flags
+        Artisan::call('translations:sort', [
+            '--nested' => true,
+            '--all' => true,
+        ]);
+
+        // Verify PHP files for all languages are sorted alphabetically
+        $this->assertNestedFileSorted('fr', 'home');
+        $this->assertNestedFileSorted('it', 'dashboard');
+
+        // Verify content is preserved
+        $this->assertNestedFileContains('fr', 'home', [
+            'aitem' => 'A Item FR',
+            'zitem' => 'Z Item FR',
+        ]);
+
+        $this->assertNestedFileContains('it', 'dashboard', [
+            'ametric' => 'A Metric IT',
+            'zmetric' => 'Z Metric IT',
+        ]);
     }
 }

--- a/tests/Extractors/PhpBaseClassExtractorTest.php
+++ b/tests/Extractors/PhpBaseClassExtractorTest.php
@@ -51,6 +51,12 @@ class PhpBaseClassExtractorTest extends TestCase
     #[Test]
     public function getEmptyIfFilePermissionFails(): void
     {
+        // Skip this test on Windows as chmod does not have the same effect
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $this->markTestSkipped('Skipping permission test on Windows');
+            return;
+        }
+
         $filePath = $this->tempDir . '/permission.php';
         file_put_contents($filePath, $this->phpControllerFile);
 

--- a/tests/Extractors/PhpBaseClassExtractorTest.php
+++ b/tests/Extractors/PhpBaseClassExtractorTest.php
@@ -51,8 +51,7 @@ class PhpBaseClassExtractorTest extends TestCase
     #[Test]
     public function getEmptyIfFilePermissionFails(): void
     {
-        // Skip this test on Windows as chmod does not have the same effect
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        if (PHP_OS_FAMILY === 'Windows') {
             $this->markTestSkipped('Skipping permission test on Windows');
             return;
         }

--- a/tests/File/Language/LanguageDirectoryManagerTest.php
+++ b/tests/File/Language/LanguageDirectoryManagerTest.php
@@ -33,7 +33,21 @@ class LanguageDirectoryManagerTest extends TestCase
         });
 
         $this->assertCount(2, $files);
-        $this->assertEquals($this->translationFile, $files[0]->getPathname());
-        $this->assertEquals($this->secondTranslationFile, $files[1]->getPathname());
+        $this->assertEquals(
+            $this->normalizePath($this->translationFile),
+            $this->normalizePath($files[0]->getPathname())
+        );
+        $this->assertEquals(
+            $this->normalizePath($this->secondTranslationFile),
+            $this->normalizePath($files[1]->getPathname())
+        );
+    }
+
+    private function normalizePath(string $path): string
+    {
+        if (PHP_OS_FAMILY !== 'Windows') {
+            return $path;
+        }
+        return str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
     }
 }

--- a/tests/File/Language/LanguageFileManagerTest.php
+++ b/tests/File/Language/LanguageFileManagerTest.php
@@ -55,24 +55,26 @@ class LanguageFileManagerTest extends TestCase
             'greeting' => 'Hello User',
         ];
         $jsonManager->updateFile($translations);
-        $jsonContent = file_get_contents($this->tempFile);
-        $lines = explode(PHP_EOL, $jsonContent);
 
-        //remove last line as it's curly bracket
+        // Normalize line endings before exploding
+        $jsonContent = str_replace("\r\n", "\n", file_get_contents($this->tempFile));
+        $lines = explode("\n", $jsonContent);
+
+        // Remove last line (closing bracket)
         array_pop($lines);
         $lastLine = end($lines);
-        $this->assertStringNotContainsString(',', $lastLine);
+        $this->assertStringNotContainsString(',', trim($lastLine));
 
         $jsonManager->updateFile(['new' => 'add new']);
-        $this->assertStringNotContainsString(',', $lastLine);
 
-        $jsonContent = file_get_contents($this->tempFile);
-        $lines = explode(PHP_EOL, $jsonContent);
+        // Normalize again for second check
+        $jsonContent = str_replace("\r\n", "\n", file_get_contents($this->tempFile));
+        $lines = explode("\n", $jsonContent);
         array_pop($lines);
         $lastLine = end($lines);
 
-        $this->assertStringNotContainsString(',', $lastLine);
-        $this->assertStringContainsString('add new', $lastLine);
+        $this->assertStringNotContainsString(',', trim($lastLine));
+        $this->assertStringContainsString('add new', trim($lastLine));
     }
 
     #[Test]

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -147,6 +147,20 @@ class TestCase extends \Orchestra\Testbench\TestCase
         }
     }
 
+    public function assertNestedFileSorted(string $language, string $filename): void
+    {
+        $filePath = $this->tempDir . '/lang/' . $language . '/' . $filename . '.php';
+        $this->assertFileExists($filePath);
+        $fileContents = require $filePath;
+
+        $keys = array_keys($fileContents);
+
+        $sortedKeys = $keys;
+        sort($sortedKeys);
+
+        $this->assertSame($sortedKeys, $keys, "Keys in {$language}/{$filename}.php are not sorted alphabetically");
+    }
+
     /**
      * @param \Illuminate\Foundation\Application $app
      * @return array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         parent::setUp();
         error_reporting(E_ALL);
         $this->tempDir = sys_get_temp_dir() . '/bottelet-translation-checker-test';
-        if (! file_exists($this->tempDir)) {
+        if (!file_exists($this->tempDir)) {
             mkdir($this->tempDir, 0777, true);
         }
 
@@ -48,7 +48,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function tearDown(): void
     {
-        $iterator    = new RecursiveDirectoryIterator($this->tempDir, FilesystemIterator::SKIP_DOTS);
+        $iterator = new RecursiveDirectoryIterator($this->tempDir, FilesystemIterator::SKIP_DOTS);
         $files = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST);
         foreach ($files as $file) {
             if ($file instanceof SplFileInfo && $file->isFile()) {
@@ -77,29 +77,29 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         $this->bladeFile = $this->createTempFile(
             'test.blade.php',
-            file_get_contents(__DIR__.'/Files/templates/underscore-translations.blade.php'),
+            file_get_contents(__DIR__ . '/Files/templates/underscore-translations.blade.php'),
         );
 
         $this->phpControllerFile = $this->createTempFile(
             'TestController.php',
-            file_get_contents(__DIR__.'/Files/templates/TestController.php'),
+            file_get_contents(__DIR__ . '/Files/templates/TestController.php'),
         );
 
         $this->vueFile = $this->createTempFile(
             'test.vue',
-            file_get_contents(__DIR__.'/Files/templates/dollar-t.vue'),
+            file_get_contents(__DIR__ . '/Files/templates/dollar-t.vue'),
         );
 
         $this->noTranslationsBladeFile = $this->createTempFile(
             'empty.blade.php',
-            file_get_contents(__DIR__.'/Files/templates/no-translations.blade.php'),
+            file_get_contents(__DIR__ . '/Files/templates/no-translations.blade.php'),
         );
     }
 
     public function createJsonTranslationFile(string $name, string|array $content = ''): string
     {
-        $translationFile = $this->tempDir."/lang/{$name}.json";
-        if (! file_exists(dirname($translationFile))) {
+        $translationFile = $this->tempDir . "/lang/{$name}.json";
+        if (!file_exists(dirname($translationFile))) {
             mkdir(dirname($translationFile), 0777, true);
         }
         if (is_array($content)) {
@@ -112,17 +112,43 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     public function createPhpTranslationFile(string $fullPath, array $content = []): string
     {
-        $translationFile = $this->tempDir.'/lang/'.$fullPath;
-        if (! file_exists(dirname($translationFile))) {
+        $translationFile = $this->tempDir . '/lang/' . $fullPath;
+        if (!file_exists(dirname($translationFile))) {
             mkdir(dirname($translationFile), 0777, true);
         }
 
-        file_put_contents($translationFile, '<?php return '.var_export($content, true).';');
+        file_put_contents($translationFile, '<?php return ' . var_export($content, true) . ';');
 
         return $translationFile;
     }
+
+    public function createNestedTranslationFile(string $language, string $filename, array $content = []): string
+    {
+        $languageDir = $this->tempDir . '/lang/' . $language;
+        if (!file_exists($languageDir)) {
+            mkdir($languageDir, 0777, true);
+        }
+
+        $filePath = $languageDir . '/' . $filename . '.php';
+        file_put_contents($filePath, "<?php\n\nreturn " . var_export($content, true) . ";\n");
+
+        return $filePath;
+    }
+
+    public function assertNestedFileContains(string $language, string $filename, array $expectedContent): void
+    {
+        $filePath = $this->tempDir . '/lang/' . $language . '/' . $filename . '.php';
+        $this->assertFileExists($filePath);
+        $fileContents = require $filePath;
+
+        foreach ($expectedContent as $key => $value) {
+            $this->assertArrayHasKey($key, $fileContents);
+            $this->assertEquals($value, $fileContents[$key]);
+        }
+    }
+
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param \Illuminate\Foundation\Application $app
      * @return array
      */
     protected function getPackageProviders($app)


### PR DESCRIPTION
### ✨ **New Feature:**
- Added `--nested` flag to support one-level nested translations
- Converts dot notation (e.g. `home.services.title`) to nested array format:
```php
  // In home.php
  'services.title' => 'Translation'
```


### **Usage:**
```bash
php artisan translation:check--nested en
```

### Current Status
✅ Implemented for:
- translations:check
- translations:clean
- translations:sort

### 🛠️ Remaining:
- translations:find-missing
- translations:sync

### :bug: Known Issues
- Currently removes PHP comments in translation files during processing
- These willbe addressed in a follow-up PR after architecture confirmation